### PR TITLE
原来的 DryRun 方法重命名为 DryRunRaw，新增 DryRun 方法

### DIFF
--- a/client/jsonrpc/transport/http.go
+++ b/client/jsonrpc/transport/http.go
@@ -4,10 +4,11 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"github.com/pkg/errors"
-	"github.com/starcoinorg/starcoin-go/client/jsonrpc/codec"
 	"io/ioutil"
 	"net/http"
+
+	"github.com/pkg/errors"
+	"github.com/starcoinorg/starcoin-go/client/jsonrpc/codec"
 )
 
 // HTTP is an http transport
@@ -74,7 +75,7 @@ func (h *HTTP) Call(context context.Context, method string, out interface{}, par
 	}
 
 	if err := json.Unmarshal(response.Result, out); err != nil {
-		return errors.Wrap(err, "parse result failed")
+		return errors.Wrap(err, "parse result failed. "+string(response.Result))
 	}
 	return nil
 }

--- a/client/starcoin_client_test.go
+++ b/client/starcoin_client_test.go
@@ -219,7 +219,7 @@ func TestDeployContract(t *testing.T) {
 	client.DeployContract(context.Background(), *toAddr, privateKey, scriptFunction, code)
 }
 
-func TestDryRun(t *testing.T) {
+func TestDryRunRaw(t *testing.T) {
 	client := NewStarcoinClient("http://localhost:9850")
 	context := context.Background()
 
@@ -261,7 +261,37 @@ func TestDryRun(t *testing.T) {
 		t.Errorf("%+v", err)
 	}
 
-	result, err := client.DryRun(context, *rawUserTransaction, senderPk)
+	result, err := client.DryRunRaw(context, *rawUserTransaction, senderPk)
+	if err != nil {
+		t.Errorf("%+v", err)
+	}
+
+	fmt.Println(result)
+}
+
+func TestEstimateGas(t *testing.T) {
+	client := NewStarcoinClient("http://localhost:9850")
+	context := context.Background()
+
+	sender := "0x569ab535990a17ac9afd1bc57faec683"
+	senderPk, _ := HexStringToBytes("0xe4cb4052dc3398f3794918f5650fdefb0a5272c4d51220fbf9538ca2c379b00b")
+	receiver := "0x17d882a26d86ccb0eedae1bd3db4f47c"
+
+	price, err := client.GetGasUnitPrice(context)
+	if err != nil {
+		t.Errorf("%+v", err)
+	}
+
+	//state, err := client.GetState(context, sender)
+	seqNumber, err := client.GetAccountSequenceNumber(context, sender)
+
+	if err != nil {
+		t.Errorf("%+v", err)
+	}
+
+	chainId := 254
+	result, err := client.EstimateGas(context, chainId, price, DEFAULT_MAX_GAS_AMOUNT, sender, senderPk, seqNumber,
+		"0x01::TransferScripts::peer_to_peer_v2", []string{"0x01::STC::STC"}, []string{receiver, "1u128"})
 	if err != nil {
 		t.Errorf("%+v", err)
 	}

--- a/client/types.go
+++ b/client/types.go
@@ -107,6 +107,22 @@ type Block struct {
 	Uncles      []BlockHeader `json:"uncles"`
 }
 
+type DryRunParam struct {
+	ChainId         int               `json:"chain_id"`
+	GasUnitPrice    int               `json:"gas_unit_price"`
+	Sender          string            `json:"sender"`
+	SenderPublicKey string            `json:"sender_public_key"`
+	SequenceNumber  uint64            `json:"sequence_number"`
+	MaxGasAmount    uint64            `json:"max_gas_amount"`
+	Script          DryRunParamScript `json:"script"`
+}
+
+type DryRunParamScript struct {
+	Code     string   `json:"code"`
+	TypeArgs []string `json:"type_args"`
+	Args     []string `json:"args"`
+}
+
 type DryRunResult struct {
 	ExplainedStatus string     `json:"explained_status"`
 	Events          []Event    `json:"events"`


### PR DESCRIPTION
以对应 RPC 中的同名方法（dry_run_raw 和 dry_run），并增加 EstimateGas 方法。