### PR TITLE
增加 HeaderByNumber 方法及 client 包中的 BlockHeader 的 Hash 方法

### DIFF
--- a/client/starcoin_client.go
+++ b/client/starcoin_client.go
@@ -140,6 +140,18 @@ func (this *StarcoinClient) GetBlockByNumber(context context.Context, number int
 	return result, nil
 }
 
+func (this *StarcoinClient) HeaderByNumber(context context.Context, number uint64) (*BlockHeader, error) {
+	result := &Block{}
+	params := []uint64{number}
+	err := this.Call(context, "chain.get_block_by_number", result, params)
+
+	if err != nil {
+		return nil, errors.Wrap(err, "call method chain.get_block_by_number ")
+	}
+
+	return &result.BlockHeader, nil
+}
+
 func (this *StarcoinClient) GetBlocksFromNumber(context context.Context, number, count int) ([]Block, error) {
 	var result []Block
 	params := []int{number, count}

--- a/client/utils_test.go
+++ b/client/utils_test.go
@@ -2,8 +2,11 @@ package client
 
 import (
 	"encoding/hex"
-	"github.com/starcoinorg/starcoin-go/types"
+	"encoding/json"
+	"fmt"
 	"testing"
+
+	"github.com/starcoinorg/starcoin-go/types"
 
 	"github.com/novifinancial/serde-reflection/serde-generate/runtime/golang/serde"
 )
@@ -84,4 +87,30 @@ func TestGetSingedUserTransactionHash(t *testing.T) {
 	if txnHash != "11de0717f09fe1fcdb320b60ac464b7830ee4fcb19774305eb41ac42b9ff7329" {
 		t.Error("txn hash is not right")
 	}
+}
+
+func TestBlockHeaderHash(t *testing.T) {
+	j := `
+	{
+		"block_hash": "0x6819736ab264bcacc468f64b4e35757f24b18d3a9180cba5c5bac14610c5c968",
+		"parent_hash": "0x3a06de3042a4b8fe156c4ae88d93e7a2e23d621965eddf46351d13d3e8ba3bb6",
+		"timestamp": "1616846974851",
+		"number": "0",
+		"author": "0x00000000000000000000000000000001",
+		"author_auth_key": null,
+		"txn_accumulator_root": "0x3b16c0b5139330b08b5e51808b5e8bb19293923c0c16b9f8ca9bb89b733ca851",
+		"block_accumulator_root": "0x414343554d554c41544f525f504c414345484f4c4445525f4841534800000000",
+		"state_root": "0xf9015ebfbb74d8dbba119f581c2c5046a289c16d01d6e731691f3c3cb82583a1",
+		"gas_used": "0",
+		"difficulty": "0x03bd",
+		"body_hash": "0x9f8f447f9d07a70e549a20ef074e0d4c6fc6b528ee772fcbb101d19b19ba419e",
+		"chain_id": 251,
+		"nonce": 0,
+		"extra": "0x00000000"
+	  }
+	`
+	h := BlockHeader{}
+	json.Unmarshal([]byte(j), &h)
+	fmt.Println(h.Hash())
+
 }

--- a/types/utils.go
+++ b/types/utils.go
@@ -18,7 +18,6 @@ func (header BlockHeader) GetHash() (*HashValue, error) {
 	result = Hash(PrefixHash("BlockHeader"), headerBytes)
 
 	return &result, nil
-
 }
 
 func Hash(prefix, data []byte) []byte {


### PR DESCRIPTION
增加 HeaderByNumber 方法。（另建议高度 number 使用 uint64，便于和其他库/链交互。）
增加 client 包中的 Block Header 的 Hash 方法。
