### PR TITLE
client 用完没有关闭

### DIFF
--- a/client/starcoin_client.go
+++ b/client/starcoin_client.go
@@ -37,6 +37,7 @@ func (this *StarcoinClient) Call(context context.Context, serviceMethod string, 
 	if err != nil {
 		return errors.Wrap(err, fmt.Sprintf("call method %s err: ", serviceMethod))
 	}
+	defer client.Close()
 
 	err = client.Call(context, serviceMethod, reply, args)
 


### PR DESCRIPTION
这里每次 调用 Call 都会新创建一个 Client， 所以需要 close. 防止 goroutinue 泄漏